### PR TITLE
Refactor website and founded date display in church profile view

### DIFF
--- a/src/components/common/admin/settings/church-settings/profile/view.tsx
+++ b/src/components/common/admin/settings/church-settings/profile/view.tsx
@@ -37,7 +37,13 @@ export default function ViewProfile() {
           </li>
           <li className="text-base flex flex-col gap-2 text-textDark px-2 py-1 border-b">
             <h4>Website</h4>
-            <a href={data?.website} target='_blank' className="text-lg hover:text-main_DarkBlueHover hover:underline text-textGray font-medium">{data?.website}</a>
+            <a
+              href={data?.website}
+              target="_blank"
+              className="text-lg hover:text-main_DarkBlueHover hover:underline text-textGray font-medium"
+            >
+              {data?.website}
+            </a>
           </li>
           <li className="text-base flex flex-col gap-2 text-textDark px-2 py-1 border-b">
             <h4>Email</h4>
@@ -58,7 +64,9 @@ export default function ViewProfile() {
           <li className="text-base flex flex-col gap-2 text-textDark px-2 py-1 border-b">
             <h4>Founded</h4>
             <p className="text-lg text-textGray font-medium">
-              {formatDate(data?.foundedDate  || "") || 'None'}
+              {data?.foundedDate
+                ? formatDate(data?.foundedDate)
+                : 'Not Specified'}
             </p>
           </li>
           <li className="text-base flex flex-col gap-2 text-textDark px-2 py-1 border-b">


### PR DESCRIPTION
**The Error brought upon me by the frontend engineers**

This pull request includes changes to the `ViewProfile` component in the `src/components/common/admin/settings/church-settings/profile/view.tsx` file. The changes focus on improving code readability and handling null or undefined values more gracefully.

Code readability improvements:

* Reformatted the `Website` link to improve code readability by breaking the line into multiple lines and properly indenting the code. (`src/components/common/admin/settings/church-settings/profile/view.tsx`)

Handling null or undefined values:

* Modified the `Founded` date display to handle null or undefined values more gracefully by checking if `data?.foundedDate` exists before formatting it. (`src/components/common/admin/settings/church-settings/profile/view.tsx`)